### PR TITLE
Fix indentation in buttons.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 Doxyfile*
 doxygen_sqlite3.db
 html
+raspberry_pi/*.o
+raspberry_pi/demo1-snow
+raspberry_pi/demo2-hourglass
+raspberry_pi/demo3-logo

--- a/raspberry_pi/buttons.py
+++ b/raspberry_pi/buttons.py
@@ -33,7 +33,7 @@ def launch():
     global PROCESS
     if PROCESS is not None:
         PROCESS.terminate()
-	while PROCESS.poll() is not None:
+        while PROCESS.poll() is not None:
             continue     # Wait for process to terminate
         time.sleep(0.25) # No, really, wait (seemingly necessary kludge)
     PROCESS = subprocess.Popen(["./" + PROGRAMS[MODE]] + FLAGS)


### PR DESCRIPTION
The Python script `raspberry_pi/buttons.py` is using a mixed tab and space indentation which makes it un-runnable. I fixed this by changing the tab into 8 spaces. I believe this is the correct indentation now.

I also added the compiled binaries and object files to the `.gitignore` to make it easier to commit this change.